### PR TITLE
Improve sync script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .classpath
 .project
 .settings
+**/__pycache__
+**/.idea
+/external_sync/settings.py

--- a/external_sync/common.py
+++ b/external_sync/common.py
@@ -13,5 +13,6 @@ def create_keycloak_admin_client() -> KeycloakAdmin:
             client_id=settings.client_id,
             client_secret_key=settings.client_secret,
             user_realm_name="master",
-            verify=True
+            verify=True,
+            auto_refresh_token=['get', 'post', 'put', 'delete']
         )

--- a/external_sync/settings.example.py
+++ b/external_sync/settings.example.py
@@ -15,3 +15,7 @@ field_sync_id = "sync_id"
 field_verified = "verified"
 field_eligible = "eligible"
 field_department = "department"
+
+# Generate output file containing all departments with no display name
+generate_missing_display_names = True
+missing_display_name_file = "missing_display_names.txt"

--- a/external_sync/update_users.py
+++ b/external_sync/update_users.py
@@ -7,9 +7,7 @@ Expected CSV format and Keycloak access settings can be configured via settings.
 """
 import csv
 import logging
-from os import dup
 import sys
-from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import List, Optional, Set
@@ -21,6 +19,8 @@ from eliot.stdlib import EliotHandler
 
 import settings
 from common import create_keycloak_admin_client
+
+URL_ADMIN_USER_LOGOUT = "admin/realms/{realm-name}/users/{id}/logout"
 
 root_logger = logging.getLogger()
 root_logger.setLevel(logging.DEBUG)
@@ -50,7 +50,7 @@ def prepare_user_updates(csv_filepath: str) -> List[UserUpdate]:
 
     users = []
 
-    with start_action(action_type="prepare_updates") as action:
+    with start_action(action_type="prepare_updates"):
         for ll, row in enumerate(user_rows):
             try:
                 sync_id = row[settings.field_sync_id]
@@ -91,7 +91,8 @@ register_exception_extractor(SyncCheckFailed, lambda e: {"case": e.case})
 def get_user_update(user, updates_by_email, updates_by_sync_id, used_sync_ids: Set[str], duplicate_sync_ids: Set[str]):
 
     with start_action(action_type="get_user_update") as action:
-        keycloak_sync_id = get_attr(user.get('attributes'), "sync_id").strip()
+        keycloak_sync_id = get_attr(user.get('attributes'), "sync_id")
+        keycloak_sync_id = keycloak_sync_id.strip() if keycloak_sync_id else ""
         keycloak_email = user['email']
 
         if keycloak_sync_id:
@@ -166,7 +167,7 @@ def update_keycloak_user_attrs(keycloak_admin, user, user_update):
             "last_sync": now_iso
         }
 
-        if "last_sync" not in current_attrs:
+        if "first_sync" not in current_attrs:
             updated_attrs["first_sync"] = now_iso
             action.add_success_fields(is_first_sync=True)
         else:
@@ -204,7 +205,7 @@ def update_keycloak_user_group(keycloak_admin, default_group_id, user, user_upda
         for group in keycloak_admin.get_user_groups(user_id):
             if group["id"] == wanted_group_id:
                 group_found = True
-            else:
+            elif group["path"].startswith(settings.parent_group_path):
                 with start_action(action_type="group_user_remove", group_id=group["id"], group_name=group["name"]):
                     keycloak_admin.group_user_remove(user_id, group["id"])
 
@@ -212,40 +213,62 @@ def update_keycloak_user_group(keycloak_admin, default_group_id, user, user_upda
             with start_action(action_type="group_user_add", group_id=wanted_group_id, group_name=user_update.department):
                 keycloak_admin.group_user_add(user_id, wanted_group_id)
 
-def disable_keycloak_user(keycloak_admin, user, reason):
-    with start_action(action_type="disable_keycloak_user") as action:
+
+def remove_user_attributes_and_groups(keycloak_admin, user, do_update=True):
+    with start_action(action_type="remove_user_attributes"):
         current_attrs = user.get('attributes', {})
 
         updated_attrs = {
-            **current_attrs,
-            'disable_reason': reason
+            **current_attrs
         }
 
+        # Delete verified and eligible state
         if "verified" in updated_attrs:
             del updated_attrs["verified"]
 
         if "eligible" in updated_attrs:
             del updated_attrs["eligible"]
 
+        # Delete all groups
         for group in keycloak_admin.get_user_groups(user["id"]):
-            with start_action(action_type="group_user_remove", group_id=group["id"], group_name=group["name"]):
-                keycloak_admin.group_user_remove(user["id"], group["id"])
+            if group["path"].startswith(settings.parent_group_path):
+                with start_action(action_type="group_user_remove", group_id=group["id"], group_name=group["name"]):
+                    keycloak_admin.group_user_remove(user["id"], group["id"])
 
-        keycloak_admin.update_user(user_id=user["id"], payload={"attributes": updated_attrs, "enabled": False})
+        if do_update:
+            keycloak_admin.update_user(user_id=user["id"], payload={"attributes": updated_attrs})
+
+        return updated_attrs
+
+
+def disable_keycloak_user(keycloak_admin, user, reason):
+    with start_action(action_type="disable_keycloak_user"):
+
+        attributes = remove_user_attributes_and_groups(keycloak_admin, user, False)
+        attributes["disable_reason"] = reason
+
+        keycloak_admin.update_user(user_id=user["id"], payload={"attributes": attributes, "enabled": False})
+
+
+def logout_everywhere(keycloak_admin, user):
+    with start_action(action_type="logout_everywhere"):
+        params = {"realm-name": keycloak_admin.realm_name, "id": user["id"]}
+        data_raw = keycloak_admin.raw_post(URL_ADMIN_USER_LOGOUT.format(**params), data=None)
+        keycloak.raise_error_from_response(data_raw, keycloak.KeycloakGetError, expected_codes=[204])
 
 
 def get_used_and_dup_sync_ids(keycloak_users: List[dict]):
     with start_action(action_type="get_used_and_dup_sync_ids") as action:
         users_by_sync_id = {}
         for user in keycloak_users:
-            sync_id = get_attr(user.get('attributes'), 'sync_id').strip()
+            sync_id = get_attr(user.get('attributes'), 'sync_id')
+            sync_id = sync_id.strip() if sync_id else ""
 
             if sync_id:
                 users_with_same_sync_id = users_by_sync_id.setdefault(sync_id, [])
                 users_with_same_sync_id.append(user)
 
         duplicate_sync_ids = set()
-
 
         for sync_id, users in users_by_sync_id.items():
             if len(users) > 1:
@@ -264,11 +287,8 @@ def update_keycloak_users(user_updates: List[UserUpdate]):
     keycloak_admin = create_keycloak_admin_client()
 
     with start_action(action_type="get_keycloak_users") as action:
-        keycloak_users_all = keycloak_admin.get_users({'search': '@'})
-        action.add_success_fields(all_keycloak_users=len(keycloak_users_all))
-
-        keycloak_users = [user for user in keycloak_users_all if user.get("emailVerified")]
-        action.add_success_fields(email_verified_keycloak_users=len(keycloak_users))
+        keycloak_users = keycloak_admin.get_users({'search': '@'})
+        action.add_success_fields(keycloak_users=len(keycloak_users))
 
     with start_action(action_type="get_keycloak_groups") as action:
         parent_group = keycloak_admin.get_group_by_path(settings.parent_group_path)
@@ -284,8 +304,17 @@ def update_keycloak_users(user_updates: List[UserUpdate]):
 
     used_sync_ids, duplicate_sync_ids = get_used_and_dup_sync_ids(keycloak_users)
 
+    keycloak_users_no_verified_email = [user for user in keycloak_users if not user.get("emailVerified")]
+
+    with start_action(action_type="non_verified_users"):
+        for user in keycloak_users_no_verified_email:
+            remove_user_attributes_and_groups(keycloak_admin, user)
+            logout_everywhere(keycloak_admin, user)
+
+    keycloak_users_verified_email = [user for user in keycloak_users if user.get("emailVerified")]
+
     with start_action(action_type="update_keycloak"):
-        for user in keycloak_users:
+        for user in keycloak_users_verified_email:
             try:
                 with start_action(action_type="update_keycloak_user", user_id=user["id"]):
                     user_update = get_user_update(user, updates_by_email, updates_by_sync_id, used_sync_ids, duplicate_sync_ids)
@@ -293,8 +322,14 @@ def update_keycloak_users(user_updates: List[UserUpdate]):
                     update_keycloak_user_group(keycloak_admin, parent_group["id"], user, user_update, group_ids_by_name)
 
             # Disable if syncing failed for a user (e.g. user no longer a member)
-            except Exception as e:
-                disable_keycloak_user(keycloak_admin, user, str(e))
+            except SyncCheckFailed as e:
+                with start_action(action_type="sync_check_failed", user_id=user["id"], problem=str(e)):
+                    disable_keycloak_user(keycloak_admin, user, str(e))
+                    logout_everywhere(keycloak_admin, user)
+
+            # Ignore other exceptions
+            except Exception:
+                log_message(message_type="user_update_exception", user_id=user["id"], exception=e)
 
 
 def main(csv_filepath: str):

--- a/external_sync/update_users.py
+++ b/external_sync/update_users.py
@@ -181,7 +181,7 @@ def update_keycloak_user_attrs(keycloak_admin, user, user_update):
             if changed:
                 action.add_success_fields(changed=changed)
 
-        keycloak_admin.update_user(user_id=user["id"], payload={"attributes": updated_attrs, "enabled": true})
+        keycloak_admin.update_user(user_id=user["id"], payload={"attributes": updated_attrs, "enabled": True})
 
 
 def update_keycloak_user_group(keycloak_admin, default_group_id, user, user_update, group_ids_by_name):
@@ -210,7 +210,7 @@ def update_keycloak_user_group(keycloak_admin, default_group_id, user, user_upda
 
 def disable_keycloak_user(keycloak_admin, user):
     with start_action(action_type="disable_keycloak_user") as action:
-        keycloak_admin.update_user(user_id=user["id"], payload={"enabled": false})
+        keycloak_admin.update_user(user_id=user["id"], payload={"enabled": False})
 
 
 def get_used_and_dup_sync_ids(keycloak_users: List[dict]):

--- a/external_sync/update_users.py
+++ b/external_sync/update_users.py
@@ -220,10 +220,10 @@ def disable_keycloak_user(keycloak_admin, user, reason):
             'disable_reason': reason
         }
 
-        if verified in updated_attrs:
+        if "verified" in updated_attrs:
             del updated_attrs["verified"]
 
-        if eligible in updated_attrs:
+        if "eligible" in updated_attrs:
             del updated_attrs["eligible"]
 
         keycloak_admin.update_user(user_id=user["id"], payload={"attributes": updated_attrs, "enabled": False})

--- a/external_sync/update_users.py
+++ b/external_sync/update_users.py
@@ -159,7 +159,8 @@ def update_keycloak_user_attrs(keycloak_admin, user, user_update):
         now_iso = datetime.now(timezone.utc).isoformat()
 
         updated_attrs = {
-            **current_attrs, 'verified': user_update.verified,
+            **current_attrs,
+            'verified': user_update.verified,
             'eligible': user_update.eligible,
             "sync_id": user_update.sync_id,
             "last_sync": now_iso
@@ -225,6 +226,10 @@ def disable_keycloak_user(keycloak_admin, user, reason):
 
         if "eligible" in updated_attrs:
             del updated_attrs["eligible"]
+
+        for group in keycloak_admin.get_user_groups(user["id"]):
+            with start_action(action_type="group_user_remove", group_id=group["id"], group_name=group["name"]):
+                keycloak_admin.group_user_remove(user_id, group["id"])
 
         keycloak_admin.update_user(user_id=user["id"], payload={"attributes": updated_attrs, "enabled": False})
 

--- a/external_sync/update_users.py
+++ b/external_sync/update_users.py
@@ -91,7 +91,7 @@ register_exception_extractor(SyncCheckFailed, lambda e: {"case": e.case})
 def get_user_update(user, updates_by_email, updates_by_sync_id, used_sync_ids: Set[str], duplicate_sync_ids: Set[str]):
 
     with start_action(action_type="get_user_update") as action:
-        keycloak_sync_id = get_attr(user.get('attributes'), "sync_id")
+        keycloak_sync_id = get_attr(user.get('attributes'), "sync_id").strip()
         keycloak_email = user['email']
 
         if keycloak_sync_id:
@@ -227,7 +227,7 @@ def get_used_and_dup_sync_ids(keycloak_users: List[dict]):
     with start_action(action_type="get_used_and_dup_sync_ids") as action:
         users_by_sync_id = {}
         for user in keycloak_users:
-            sync_id = get_attr(user.get('attributes'), 'sync_id')
+            sync_id = get_attr(user.get('attributes'), 'sync_id').strip()
 
             if sync_id:
                 users_with_same_sync_id = users_by_sync_id.setdefault(sync_id, [])

--- a/external_sync/update_users.py
+++ b/external_sync/update_users.py
@@ -229,7 +229,7 @@ def disable_keycloak_user(keycloak_admin, user, reason):
 
         for group in keycloak_admin.get_user_groups(user["id"]):
             with start_action(action_type="group_user_remove", group_id=group["id"], group_name=group["name"]):
-                keycloak_admin.group_user_remove(user_id, group["id"])
+                keycloak_admin.group_user_remove(user["id"], group["id"])
 
         keycloak_admin.update_user(user_id=user["id"], payload={"attributes": updated_attrs, "enabled": False})
 

--- a/themes/ekklesia/account/template.ftl
+++ b/themes/ekklesia/account/template.ftl
@@ -71,7 +71,7 @@
         </div>
 
         <div class="col-sm-9 content-area">
-            <#if account.attributes.first_sync??>
+            <#if account.attributes.eligible??>
                 <div class="alert alert-info">
                   <span class="pficon pficon-ok"></span>
                   <span class="kc-feedback-text">${msg("syncInfoYes")}</span>


### PR DESCRIPTION
Tested all potential problems we discussed. Most important changes are:

- Disable user when the sync fails for any reason (e.g. invalid token, etc.), also remove verified and eligible attributes and groups
- Only consider users with verified email addresses for syncing
- Remove verified and eligible attributes and groups on users with unverified email adresses
- Call logout API to log the user out everywhere when the account is disabled or the email is unverified
- Show the account info message dependent on the existence of the eligible flag instead of the first_sync attribute, because this attribute will still exist when a user is marked invalid

The smaller changes:
- Allow the script to refresh api access tokens
- Strip sync ids, so that spaces at the beginning and the end don't matter
- Only delete groups that have the configured group root as parent